### PR TITLE
parallelized, and more aggressive, error correction

### DIFF
--- a/error_correct.py
+++ b/error_correct.py
@@ -5,7 +5,7 @@ import pandas as pd
 import numpy as np
 from typing import Tuple, TextIO
 from jellyfish import hamming_distance
-import sys
+import multiprocessing
 
 
 def fasta_parse(fasta: str):
@@ -15,24 +15,28 @@ def fasta_parse(fasta: str):
     fasta: path to FASTA file
     """
     fasta_dat = []
+    index = []
     for seq in parse(fasta, 'fasta'):
         id, cprimer, vprimer, abundance = (x.split('=')[-1]
                                            for x in seq.id.split('|'))
-        fasta_dat.append([id, str(seq.seq), cprimer, vprimer, int(abundance)])
+        index.append(id)
+        fasta_dat.append([str(seq.seq), cprimer, vprimer, int(abundance)])
+
     df = pd.DataFrame(fasta_dat,
-                      columns=('id', 'sequence', 'C primer', 'V primer',
+                      index=index,
+                      columns=('sequence', 'C primer', 'V primer',
                                'abundance'))
     df['length'] = df.sequence.str.len()
     return df
 
 
-def df2fasta(df: pd.DataFrame, file: TextIO = sys.stdout):
-    """print FASTA to file (default stdout) from DataFrame as parsed by
+def df2fasta(df: pd.DataFrame, file: TextIO):
+    """print FASTA to file from DataFrame as parsed by
     fasta_parse. FASTA sequence is NOT wrapped to 80 characters.
     """
     try:
         for idx in df.index:
-            print(f'>{df.loc[idx, "id"]}|CPRIMER={df.loc[idx, "C primer"]}'
+            print(f'>{idx}|CPRIMER={df.loc[idx, "C primer"]}'
                   f'|VPRIMER={df.loc[idx, "V primer"]}'
                   f'|DUPCOUNT={df.loc[idx, "abundance"]}', file=file)
             print(df.loc[idx, 'sequence'], file=file)
@@ -40,67 +44,56 @@ def df2fasta(df: pd.DataFrame, file: TextIO = sys.stdout):
         pass
 
 
-def df2parents(df: pd.DataFrame, file: TextIO = sys.stdout):
+def df2parents(df: pd.DataFrame, file: TextIO):
     """print two columns: child and parent
     """
     try:
         for idx in df.index:
             for child in df.loc[idx, 'children']:
-                print(f'{child}\t{df.loc[idx, "id"]}', file=file)
+                print(f'{child}\t{idx}', file=file)
     except BrokenPipeError:
         pass
 
 
-def error_correct(df: pd.DataFrame,
-                  delta_r: np.float32 = 1,
-                  delta_a: np.float32 = 1) -> Tuple[np.ndarray, np.ndarray]:
-    """correct errors by clustering with sparse distance computations
+def error_correct(df: pd.DataFrame, d_tol: int = 1, a_tol: np.float32 = None,
+                  name: str = '', verbose: bool = False
+                  ) -> Tuple[np.ndarray, np.ndarray]:
+    if a_tol is None:
+        a_tol = 1
 
-    df: DataFrame as returned by fasta_parse
-    delta_r: marginal Hamming distance tolerance per decade in log ratio
-             abundances
-    delta_a: marginal abundance tolerance of clusterable sequences per decade
-             in log ratio abundances (default 1)
-    """
-    df = df.sort_values(by=['V primer', 'C primer', 'length', 'abundance'],
-                        ascending=(True, True, False,
-                                   False)).reset_index(drop=True)
-    assert len(df['C primer'].unique()) == 1
+    # sort by descending abundance
+    df = df.sort_values(by='abundance', ascending=False)
 
+    # add a field for the list of children (if any), initialized empty
     df['children'] = [[] for _ in range(len(df))]
 
-    parent_idxs = np.where(df.abundance >= 10 ** (1 / delta_r))[0]
+    # the possible parents have abundance at least a_tol, since minimum
+    # abundance of child is 1
+    parent_idxs = np.where(df.abundance.values >= a_tol)[0]
 
     n_clustered = 0
 
     for ct, i in enumerate(parent_idxs, 1):
         if df.abundance.values[i] == 0:
             continue
-        block_idxs = np.where(np.logical_and(
-                              df.length.values == df.length.values[i],
-                              df['V primer'].values
-                              == df['V primer'].values[i]))[0]
-        for j in reversed(block_idxs):
+        for j in reversed(range(len(df))):
             if j == i:
                 break
-            if (df.abundance.values[i] == df.abundance.values[j]
-                    or df.abundance.values[j] == 0):
+            if df.abundance.values[j] == 0:
                 continue
-            abundance_log_ratio = (np.log10(df.abundance.values[i])
-                                   - np.log10(df.abundance.values[j]))
-            if 1 / abundance_log_ratio > delta_r:
+            abundance_ratio = df.abundance.values[i] / df.abundance.values[j]
+            if abundance_ratio < a_tol:
                 break
-            if df.abundance.values[j] / abundance_log_ratio > delta_a:
-                break
-            d = hamming_distance(df.sequence.values[i], df.sequence.values[j])
-            if d / abundance_log_ratio <= delta_r:
+            if hamming_distance(df.sequence.values[i],
+                                df.sequence.values[j]) <= d_tol:
                 df.abundance.values[i] += df.abundance.values[j]
-                df.children.values[i].append(df.id.values[j])
+                df.children.values[i].append(df.index.values[j])
                 df.abundance.values[j] = 0
                 n_clustered += 1
-        print(f'{ct / len(parent_idxs):.2%}, corrected {n_clustered}',
-              end='    \r', flush=True, file=sys.stderr)
-    print(file=sys.stderr)
+        if verbose:
+            print(name, f'{ct / len(parent_idxs):.2%}', end='      \r')
+    if verbose:
+        print()
 
     return df[df.abundance > 0]
 
@@ -112,36 +105,43 @@ def main():
     import pickle
 
     parser = argparse.ArgumentParser(
-        description='FASTA error correction, streams to stdout')
+        description='FASTA error correction')
     parser.add_argument('fasta', type=str, help='path to FASTA')
     parser.add_argument('outbase', type=str, help='basename for output files')
-    parser.add_argument('--delta_r', type=float, default=1,
-                        help='marginal Hamming distance tolerance per decade '
-                             'in log ratio abundances (default 1)')
-    parser.add_argument('--delta_a', type=float, default=1,
-                        help='marginal abundance tolerance of clusterable '
-                             'sequences per decade in log ratio abundances '
-                             '(default 1)')
+    parser.add_argument('--d_tol', type=float, default=1,
+                        help='Hamming distance tolerance (default 1)')
+    parser.add_argument('--a_tol', type=float, default=None,
+                        help='abundance ratio tolerance (if None, not '
+                             'applied)')
+    parser.add_argument('--jobs', type=int, default=1,
+                        help='number of parallel jobs (default 1)')
     parser.add_argument('--passes', type=int, default=1,
                         help='number of times to repeat greedy clustering '
                              '(default 1)')
     parser.add_argument('--keep_singletons', action='store_true',
                         help="don't discard uncorrected singletons")
+    parser.add_argument('--verbose', action='store_true',
+                        help='print progress messages')
     args = parser.parse_args()
 
     df = fasta_parse(args.fasta)
 
     for this_pass in range(1, args.passes + 1):
-        if args.passes > 1:
-            print(f'pass {this_pass}', file=sys.stderr)
-        df = error_correct(df, delta_r=args.delta_r, delta_a=args.delta_a)
+        if args.passes > 1 and args.verbose:
+            print(f'pass {this_pass}')
+        groups = df.groupby(by=['V primer', 'C primer', 'length'])
+        with multiprocessing.Pool(processes=args.jobs) as pool:
+            chunk_gen = ((df_group, args.d_tol, args.a_tol, name, args.verbose)
+                         for name, df_group in groups)
+            df = pd.concat(pool.starmap(error_correct, chunk_gen))
 
     if not args.keep_singletons:
         df = df[df.abundance > 1]
 
-    df2fasta(df, file=open(f'{args.outbase}.corrected.fa', 'w'))
-    df2parents(df, file=open(f'{args.outbase}.parents.tsv', 'w'))
+    df2fasta(df, open(f'{args.outbase}.corrected.fa', 'w'))
+    df2parents(df, open(f'{args.outbase}.parents.tsv', 'w'))
     pickle.dump(df, open(f'{args.outbase}.df.pkl', 'wb'))
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Updates to `error_correct.py`:
- collapse using absolute Hamming tolerance `--d_tol`, and optional absolute abundance ratio tolerance `--a_tol`. If the latter argument is omitted, abundance is only used to rank sequences for the greedy pass.
- parallelize over primers X lengths using the `--jobs` argument

Here's the new usage info:
```bash
$ python error_correct.py -h                                                                                                  
usage: error_correct.py [-h] [--d_tol D_TOL] [--a_tol A_TOL] [--jobs JOBS]
                        [--passes PASSES] [--keep_singletons] [--verbose]
                        fasta outbase

FASTA error correction

positional arguments:
  fasta              path to FASTA
  outbase            basename for output files

optional arguments:
  -h, --help         show this help message and exit
  --d_tol D_TOL      Hamming distance tolerance (default 1)
  --a_tol A_TOL      abundance ratio tolerance (if None, not applied)
  --jobs JOBS        number of parallel jobs (default 1)
  --passes PASSES    number of times to repeat greedy clustering (default 1)
  --keep_singletons  don't discard uncorrected singletons
  --verbose          print progress messages
```